### PR TITLE
bug fixes + failed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -51,9 +51,8 @@ It is licensed under AGPL-3.0-only. See [LICENSE](LICENSE) and [PLEDGE.md](PLEDG
 
 ## Slash commands
 
-All commands use the `/zahul` command group or standalone groups listed below.
-
-- `/zahul register_channel` — initializes the current channel for the bot
+- `/register_channel` — initializes the current channel for the bot
+- `/unregister_channel` — removes the current channel from the bot
 - `/whitelist add` — adds characters to the channel whitelist (comma-separated)
 - `/whitelist remove` — removes characters from the channel whitelist
 - `/whitelist view` — shows the current whitelist for this channel
@@ -96,7 +95,6 @@ All commands use the `/zahul` command group or standalone groups listed below.
 
 ## Adapted for Slovak Audience
 
-- Bot slash command group renamed to `/zahul`
 - All Discord slash commands and responses written in Slovak
 - `/tokens` command displays model names and limits in Slovak
 - UI panel labels and descriptions kept in English for maintainability

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Save the config, then click **Start Bot** on the main panel. An invite link will
 In your Discord server, run the following slash command in the channel you want the bot to use:
 
 ```
-/zahul register_channel
+/register_channel
 ```
 
 The bot is now active in that channel.

--- a/api/db/database.py
+++ b/api/db/database.py
@@ -456,6 +456,7 @@ class Database:
             for col_sql in [
                 "ALTER TABLE scheduled_tasks ADD COLUMN message_mode TEXT NOT NULL DEFAULT 'exact'",
                 "ALTER TABLE scheduled_tasks ADD COLUMN history_limit INTEGER",
+                "ALTER TABLE scheduled_tasks ADD COLUMN error_message TEXT",
             ]:
                 try:
                     conn.execute(col_sql)

--- a/api/models/models.py
+++ b/api/models/models.py
@@ -85,6 +85,7 @@ class CharacterData(BaseModel):
     persona: str
     instructions: str
     avatar: Optional[str] = None
+    avatar_source: Optional[str] = None
     about: Optional[str] = None
     temperature: Optional[float] = None
     history_limit: Optional[int] = None
@@ -173,3 +174,4 @@ class Task(BaseModel):
     history_limit: Optional[int] = None
     created_at: str
     next_run: Optional[str] = None
+    error_message: Optional[str] = None

--- a/api/routers/characters.py
+++ b/api/routers/characters.py
@@ -134,13 +134,26 @@ async def save_avatar(
     if not image:
         raise HTTPException(status_code=400, detail="No image provided.")
     safe_name = "".join(c for c in name if c.isalnum() or c in "-_").strip() or "avatar"
-    avatars_dir = "/app/static/avatars"
-    os.makedirs(avatars_dir, exist_ok=True)
-    file_path = f"{avatars_dir}/{safe_name}.png"
+    os.makedirs(_AVATARS_DIR, exist_ok=True)
+    file_path = f"{_AVATARS_DIR}/{safe_name}.png"
     contents = await image.read()
     with open(file_path, "wb") as f:
         f.write(contents)
+    db.log_admin('character.avatar.upload', target=safe_name)
     return {"url": f"/static/avatars/{safe_name}.png"}
+
+
+@router.post("/mirror_avatar")
+async def mirror_avatar_endpoint(
+    name: str = Query(..., description="Character name (used as filename)"),
+    url: str = Query(..., description="Image URL to download")
+):
+    """Downloads an image from a URL, saves it to static/avatars, returns the local path."""
+    local_path = await _mirror_avatar(name, url)
+    if local_path == url:
+        raise HTTPException(status_code=400, detail="Failed to download image from URL.")
+    db.log_admin('character.avatar.mirror', target=name)
+    return {"url": local_path}
 
 
 @router.get("/proxy_image")
@@ -197,8 +210,6 @@ async def create_character(
         )
     try:
         char_data = character.data.model_dump()
-        if char_data.get("avatar"):
-            char_data["avatar"] = await _mirror_avatar(character.name, char_data["avatar"])
         db.create_character(
             name=character.name,
             data=char_data,
@@ -240,8 +251,6 @@ async def update_character(
     try:
         # Step 1: Update the main character data (persona, examples, etc.)
         char_data = character_update.data.model_dump()
-        if char_data.get("avatar"):
-            char_data["avatar"] = await _mirror_avatar(character_name, char_data["avatar"])
         db.update_character(name=character_name, data=char_data)
         
         # Step 2: Update the triggers by replacing them completely
@@ -291,11 +300,12 @@ async def create_character_from_import(request: Request):
             
         # Card imports don't have triggers, so an empty list is passed
         db.create_character(name=name, data=data_dict, triggers=[])
-        
+        db.log_admin('character.import', target=name)
+
         new_character = db.get_character(name=name)
         if not new_character:
             raise HTTPException(status_code=500, detail="Failed to retrieve character after creation.")
-            
+
         return new_character
     except HTTPException as e:
         raise e # Re-raise known HTTP exceptions
@@ -331,4 +341,5 @@ async def upload_image(
             detail="Failed to upload image. Check server logs for Discord API errors or misconfigurations."
         )
 
+    db.log_admin('character.image.upload', target=image.filename)
     return {"filename": image.filename, "cdn_url": cdn_url}

--- a/api/routers/plugins.py
+++ b/api/routers/plugins.py
@@ -2,6 +2,9 @@
 from fastapi import APIRouter, Request, HTTPException
 from pydantic import BaseModel
 from typing import List, Optional
+from api.db.database import Database
+
+_db = Database()
 
 router = APIRouter(prefix="/plugins", tags=["Plugins"])
 
@@ -52,8 +55,9 @@ async def reload_plugins(request: Request):
             for p in manager.plugins
         ]
         
+        _db.log_admin('plugins.reload', detail=f"{len(info_list)} plugins loaded")
         return {
-            "status": "reloaded", 
+            "status": "reloaded",
             "count": len(manager.plugins),
             "plugins": info_list
         }

--- a/api/routers/preset.py
+++ b/api/routers/preset.py
@@ -55,6 +55,7 @@ async def create_preset(preset_data: PresetBody = Body(..., description="The new
         new_preset = db.get_preset(name=preset_data.name)
         if not new_preset:
             raise HTTPException(status_code=500, detail="Failed to retrieve preset after creation.")
+        db.log_admin('preset.create', target=preset_data.name)
         return new_preset
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to create preset: {e}")
@@ -97,8 +98,7 @@ async def update_preset(
         # Now, `update_data` only contains fields like 'description' and 'prompt_template'.
         # The `name` argument is supplied only by `preset_name` from the URL.
         db.update_preset(name=preset_name, **update_data)
-        
-        # Fetch and return the updated preset using the original name from the path
+        db.log_admin('preset.update', target=preset_name)
         return db.get_preset(name=preset_name)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to update preset: {e}")
@@ -116,6 +116,7 @@ async def delete_preset(preset_name: str = Path(..., description="The name of th
 
     try:
         db.delete_preset(name=preset_name)
-        return None  # Return an empty response for 204 No Content
+        db.log_admin('preset.delete', target=preset_name)
+        return None
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to delete preset: {e}")

--- a/api/routers/servers.py
+++ b/api/routers/servers.py
@@ -42,6 +42,7 @@ async def create_server(server: Server = Body(..., description="Server data to c
             description=server.description,
             instruction=server.instruction
         )
+        db.log_admin('server.create', target=f"{server.server_name} ({server.server_id})")
         return server
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to create server: {e}")
@@ -92,7 +93,8 @@ async def delete_server(server_id: str = Path(..., description="The unique ID of
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Server '{server_id}' not found")
     try:
         db.delete_server(server_id)
-        return None # Return empty response for 204
+        db.log_admin('server.delete', target=server_id)
+        return None
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to delete server: {e}")
 
@@ -128,7 +130,7 @@ async def create_channel(
             server_name=server["server_name"],
             data=channel_data_dict
         )
-        # Fetch the newly created channel to return the full object
+        db.log_admin('channel.create', target=f"{request.data.name} ({request.channel_id})")
         return db.get_channel(request.channel_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to create channel: {e}")
@@ -166,6 +168,7 @@ async def update_channel(
         # Use by_alias=True to correctly handle the 'global' field name
         channel_data_dict = channel_data.model_dump(by_alias=True)
         db.update_channel(channel_id, data=channel_data_dict)
+        db.log_admin('channel.update', target=f"{channel_data.name} ({channel_id})")
         return db.get_channel(channel_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to update channel: {e}")
@@ -182,6 +185,7 @@ async def delete_channel(
 
     try:
         db.delete_channel(channel_id)
+        db.log_admin('channel.delete', target=f"{existing_channel.get('data', {}).get('name', channel_id)} ({channel_id})")
         return None
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to delete channel: {e}")

--- a/api/routers/trash.py
+++ b/api/routers/trash.py
@@ -20,6 +20,14 @@ def list_trash():
     return _get_trash_db().list_all()
 
 
+@router.get("/{trash_id}")
+def get_trash_item(trash_id: int):
+    item = _get_trash_db().get(trash_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Trash item not found")
+    return item
+
+
 @router.post("/{trash_id}/restore")
 def restore(trash_id: int):
     trash_db = _get_trash_db()
@@ -36,6 +44,7 @@ def restore(trash_id: int):
         raise HTTPException(status_code=400, detail=str(e))
 
     trash_db.delete(trash_id)
+    db.log_admin('trash.restore', target=f"{item['source_table']}:{trash_id}")
     return restored
 
 

--- a/bot_run.py
+++ b/bot_run.py
@@ -71,7 +71,8 @@ class Zahul(discord.Client):
 
         # --- Slash Commands ---
         # Register command groups, passing the database instance to them
-        self.tree.add_command(CoreCommands(self.db))
+        self.tree.add_command(register_channel_command(self.db))
+        self.tree.add_command(unregister_channel_command(self.db))
         self.tree.add_command(WhitelistCommands(self.db))
         self.tree.add_command(FallbackGroup())
         self.tree.add_command(AutocapGroup())
@@ -391,9 +392,10 @@ async def _send_scheduled_message(bot: 'Zahul', task: dict):
     char_name = char['name']
     bot_config = BotConfig(**bot.db.list_configs())
     avatar_url = char_data.get('avatar')
-    if avatar_url and avatar_url.startswith('/'):
-        if bot_config.public_url:
-            avatar_url = bot_config.public_url.rstrip('/') + avatar_url
+    if avatar_url and avatar_url.startswith('/') and bot_config.public_url:
+        avatar_url = bot_config.public_url.rstrip('/') + avatar_url
+    if avatar_url and not str(avatar_url).startswith(('http://', 'https://')):
+        avatar_url = None
     instructions = (task.get('instructions') or '').strip()
     print(f"[Scheduler] sending task {task['id']} type={task.get('type')} mode={task.get('message_mode')} char={char_name} target={task.get('target_type')} id={task.get('target_id')}")
 
@@ -557,7 +559,7 @@ async def _send_scheduled_message(bot: 'Zahul', task: dict):
 
 
 async def _run_scheduler(bot: 'Zahul'):
-    """Background loop that fires due reminders and recurring schedules every minute."""
+    """Background loop that fires due reminders and recurring schedules every minute, aligned to wall-clock minutes."""
     global _last_schedule_fire
     await asyncio.sleep(10)  # let the bot fully connect first
     while True:
@@ -569,8 +571,19 @@ async def _run_scheduler(bot: 'Zahul'):
             due = bot.db.list_due_reminders(now_iso)
             for task in due:
                 print(f"[Scheduler] Firing reminder id={task['id']} scheduled_time={task.get('scheduled_time')}")
-                await _send_scheduled_message(bot, task)
-                bot.db.update_task(task['id'], status='done')
+                try:
+                    await _send_scheduled_message(bot, task)
+                    bot.db.update_task(task['id'], status='done', error_message=None)
+                except Exception as e:
+                    err = str(e)
+                    print(f"[Scheduler] Reminder id={task['id']} failed: {err}\n{traceback.format_exc()}")
+                    bot.db.update_task(task['id'], status='failed', error_message=err)
+                    bot.db.log_discord(
+                        character=task.get('character', ''), channel_id=f"{task['target_type']}:{task['target_id']}",
+                        user='system', trigger=task.get('instructions') or '', response='',
+                        model='', input_tokens=0, output_tokens=0, conversation_history=None,
+                        source='scheduler', status='error', error_message=err, history_count=0,
+                    )
 
             # Fire active schedules whose time matches now
             current_day = now.weekday()  # 0=Mon, 6=Sun
@@ -593,11 +606,25 @@ async def _run_scheduler(bot: 'Zahul'):
                         should_fire = now.month == pattern.get('month', 1) and now.day == pattern.get('day', 1)
                 if should_fire and _last_schedule_fire.get(task['id']) != today_str:
                     print(f"[Scheduler] firing schedule task {task['id']} for {task['character']} at {current_time}")
-                    await _send_scheduled_message(bot, task)
+                    try:
+                        await _send_scheduled_message(bot, task)
+                        bot.db.update_task(task['id'], error_message=None)
+                    except Exception as e:
+                        err = str(e)
+                        print(f"[Scheduler] Schedule id={task['id']} failed: {err}\n{traceback.format_exc()}")
+                        bot.db.update_task(task['id'], error_message=err)
+                        bot.db.log_discord(
+                            character=task.get('character', ''), channel_id=f"{task['target_type']}:{task['target_id']}",
+                            user='system', trigger=task.get('instructions') or '', response='',
+                            model='', input_tokens=0, output_tokens=0, conversation_history=None,
+                            source='scheduler', status='error', error_message=err, history_count=0,
+                        )
                     _last_schedule_fire[task['id']] = today_str
         except Exception:
             print(f"[Scheduler] Loop error:\n{traceback.format_exc()}")
-        await asyncio.sleep(60)
+        # Sleep until the start of the next wall-clock minute
+        now = datetime.now(SK_TZ)
+        await asyncio.sleep(60 - now.second - now.microsecond / 1_000_000)
 
 
 @app_commands.command(name="reminder", description="Set a one-time reminder in this channel or DM.")
@@ -661,27 +688,32 @@ async def reminder_command(
     )
 
 
-# --- Slash Command Groups ---
-class CoreCommands(app_commands.Group):
-    def __init__(self, db: Database):
-        super().__init__(name="zahul", description="Main bot commands")
-        self.db = db
-
+def register_channel_command(db: Database):
     @app_commands.command(name="register_channel", description="Initializes this channel for the bot.")
-    async def register_channel(self, interaction: discord.Interaction):
+    async def _register(interaction: discord.Interaction):
         server_id = str(interaction.guild.id)
         channel_id = str(interaction.channel.id)
-        
-        if not self.db.get_server(server_id):
-            self.db.create_server(server_id, interaction.guild.name)
-        
-        if self.db.get_channel(channel_id):
+        if not db.get_server(server_id):
+            db.create_server(server_id, interaction.guild.name)
+        if db.get_channel(channel_id):
             await interaction.response.send_message("This channel is already registered.", ephemeral=True)
             return
-
         default_data = {"name": interaction.channel.name, "whitelist": []}
-        self.db.create_channel(channel_id, server_id, interaction.guild.name, default_data)
+        db.create_channel(channel_id, server_id, interaction.guild.name, default_data)
         await interaction.response.send_message(f"Channel '{interaction.channel.name}' has been successfully registered!", ephemeral=True)
+    return _register
+
+
+def unregister_channel_command(db: Database):
+    @app_commands.command(name="unregister_channel", description="Removes this channel from the bot.")
+    async def _unregister(interaction: discord.Interaction):
+        channel_id = str(interaction.channel.id)
+        if not db.get_channel(channel_id):
+            await interaction.response.send_message("This channel is not registered.", ephemeral=True)
+            return
+        db.delete_channel(channel_id)
+        await interaction.response.send_message(f"Channel '{interaction.channel.name}' has been unregistered.", ephemeral=True)
+    return _unregister
 
 
 class WhitelistCommands(app_commands.Group):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,11 +33,12 @@ services:
       - "443:443/udp"
     environment:
       - PUBLIC_URL=${PUBLIC_URL}
+    entrypoint: ["/bin/sh", "-c", "if [ -z \"$$PUBLIC_URL\" ]; then echo '[caddy] PUBLIC_URL is not set, skipping.'; exit 0; fi; exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"]
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data
       - caddy_config:/config
-    restart: unless-stopped
+    restart: on-failure
     networks:
       - web
     depends_on:

--- a/static/characters.html
+++ b/static/characters.html
@@ -138,14 +138,29 @@
 
                 <!-- Avatar -->
                 <div>
-                    <label class="block mb-2 text-sm font-medium text-gray-300">Avatar</label>
-                    <div class="flex items-center gap-4">
+                    <div class="flex items-center gap-2 mb-5">
+                        <label class="text-sm font-medium text-gray-300">Avatar</label>
+                        <div class="flex rounded-lg overflow-hidden border border-gray-700 text-xs">
+                            <button type="button" id="avatar-mode-url" class="px-3 py-0.5 bg-indigo-600 text-white transition-colors">External URL</button>
+                            <button type="button" id="avatar-mode-upload" class="px-3 py-0.5 bg-gray-800 text-gray-400 hover:text-white transition-colors">Upload (static)</button>
+                        </div>
+                        <div class="relative group">
+                            <i class="fas fa-circle-info text-gray-500 hover:text-gray-300 cursor-help text-sm"></i>
+                            <div class="absolute left-0 bottom-6 w-64 bg-gray-900 border border-gray-700 rounded-lg p-3 text-xs text-gray-300 hidden group-hover:block z-50 shadow-xl">
+                                <p class="font-semibold text-white mb-1">External URL</p>
+                                <p class="mb-2 text-gray-400">URL is stored as-is - image is not downloaded.</p>
+                                <p class="font-semibold text-white mb-1">Upload (static)</p>
+                                <p class="text-gray-400">Pick a file or paste a URL - the image is downloaded and saved to <code class="text-indigo-300">static/avatars</code>.</p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-4 mb-8">
                         <img id="avatar-preview" src="" alt="" class="w-24 h-24 rounded-lg object-cover bg-gray-800 flex-shrink-0">
                         <div class="flex-grow space-y-2">
-                            <input type="text" id="avatar-url" class="bg-gray-800 border border-gray-700 text-white text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5" placeholder="Paste image URL">
+                            <input type="text" id="avatar-url" class="bg-gray-800 border border-gray-700 text-white text-sm rounded-lg focus:ring-primary focus:border-primary block w-full p-2.5" placeholder="Paste image URL (https://...)">
                             <div class="flex items-center gap-3">
-                                <input id="avatar-upload" type="file" accept="image/*" class="block text-sm text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary-dark cursor-pointer">
-                                <a href="/editor" target="_blank" class="text-xs text-indigo-400 hover:text-indigo-300 whitespace-nowrap"><i class="fas fa-external-link-alt mr-1"></i>Avatar Editor</a>
+                                <input id="avatar-upload" type="file" accept="image/*" class="invisible text-sm text-gray-400 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-primary file:text-white hover:file:bg-primary-dark cursor-pointer">
+                                <a href="/editor" target="_blank" class="text-xs text-indigo-400 hover:text-indigo-300 whitespace-nowrap ml-auto"><i class="fas fa-external-link-alt mr-1"></i>Avatar Editor</a>
                             </div>
                         </div>
                     </div>
@@ -299,6 +314,9 @@
 
                     personaInput.value = char.data.persona;
                     instructionsInput.value = char.data.instructions;
+                    _savedExternalUrl = char.data.avatar_source || '';
+                    const isStaticAvatar = char.data.avatar && char.data.avatar.startsWith('/static/');
+                    _savedStaticUrl = isStaticAvatar ? char.data.avatar : '';
                     avatarUrlInput.value = char.data.avatar || '';
                     infoInput.value = char.data.about || '';
                     temperatureInput.value = char.data.temperature != null ? char.data.temperature : '';
@@ -307,6 +325,7 @@
                     triggersInput.value = char.triggers.join(', ');
 
                     updateAvatarPreview(char.data.avatar);
+                    if (isStaticAvatar) setAvatarMode('upload');
                     saveBtn.textContent = 'Save Changes';
                     deleteBtn.classList.remove('hidden');
                     exportBtn.classList.remove('hidden');
@@ -326,6 +345,15 @@
                 deleteBtn.classList.add('hidden');
                 exportBtn.classList.add('hidden');
                 updateAvatarPreview('https://via.placeholder.com/96');
+                _savedExternalUrl = '';
+                _savedStaticUrl = '';
+                currentAvatarMode = 'url';
+                avatarModeUrl.classList.add('bg-indigo-600', 'text-white');
+                avatarModeUrl.classList.remove('bg-gray-800', 'text-gray-400');
+                avatarModeUpload.classList.add('bg-gray-800', 'text-gray-400');
+                avatarModeUpload.classList.remove('bg-indigo-600', 'text-white');
+                avatarUploadInput.classList.add('invisible');
+                avatarUploadInput.classList.remove('visible');
             }
 
             // REWORKED: Handle form submission (both create and update)
@@ -342,6 +370,7 @@
                     persona: personaInput.value,
                     instructions: instructionsInput.value,
                     avatar: avatarUrlInput.value.trim() || null,
+                    avatar_source: (currentAvatarMode === 'upload' && _savedExternalUrl) ? _savedExternalUrl : null,
                     about: infoInput.value.trim() || null,
                     temperature: temperatureInput.value !== '' ? parseFloat(temperatureInput.value) : null,
                     history_limit: charHistoryLimitInput.value !== '' ? parseInt(charHistoryLimitInput.value) : null,
@@ -438,6 +467,83 @@
                 }
             }
             
+            // Avatar mode toggle
+            const avatarModeUrl = document.getElementById('avatar-mode-url');
+            const avatarModeUpload = document.getElementById('avatar-mode-upload');
+            let currentAvatarMode = 'url';
+            let _savedExternalUrl = '';
+            let _savedStaticUrl = '';
+
+            function setAvatarMode(mode) {
+                currentAvatarMode = mode;
+                if (mode === 'url') {
+                    avatarModeUrl.classList.replace('bg-gray-800', 'bg-indigo-600');
+                    avatarModeUrl.classList.replace('text-gray-400', 'text-white');
+                    avatarModeUpload.classList.replace('bg-indigo-600', 'bg-gray-800');
+                    avatarModeUpload.classList.replace('text-white', 'text-gray-400');
+                    avatarUploadInput.classList.add('invisible');
+                    avatarUploadInput.classList.remove('visible');
+                    avatarUrlInput.placeholder = 'Paste image URL (https://...)';
+                    if (_savedExternalUrl) {
+                        avatarUrlInput.value = _savedExternalUrl;
+                        updateAvatarPreview(_savedExternalUrl);
+                    }
+                } else {
+                    avatarModeUpload.classList.replace('bg-gray-800', 'bg-indigo-600');
+                    avatarModeUpload.classList.replace('text-gray-400', 'text-white');
+                    avatarModeUrl.classList.replace('bg-indigo-600', 'bg-gray-800');
+                    avatarModeUrl.classList.replace('text-white', 'text-gray-400');
+                    avatarUploadInput.classList.remove('invisible');
+                    avatarUploadInput.classList.add('visible');
+                    avatarUrlInput.placeholder = 'Paste URL to auto-download, or pick a file below';
+                    const existingUrl = avatarUrlInput.value.trim();
+                    if (existingUrl.startsWith('http')) {
+                        if (existingUrl === _savedExternalUrl && _savedStaticUrl) {
+                            avatarUrlInput.value = _savedStaticUrl;
+                            updateAvatarPreview(_savedStaticUrl);
+                        } else {
+                            _savedExternalUrl = existingUrl;
+                            _savedStaticUrl = '';
+                            mirrorUrl(existingUrl);
+                        }
+                    }
+                }
+            }
+            avatarModeUrl.addEventListener('click', () => setAvatarMode('url'));
+            avatarModeUpload.addEventListener('click', () => setAvatarMode('upload'));
+
+            // Auto-mirror URL to static when in upload mode
+            async function mirrorUrl(url) {
+                _savedExternalUrl = url;
+                const charName = nameInput.value.trim() || 'avatar';
+                const originalUrl = avatarUrlInput.value;
+                avatarUrlInput.value = 'Downloading...';
+                saveBtn.disabled = true;
+                try {
+                    const response = await fetch(`${API_BASE}/mirror_avatar?name=${encodeURIComponent(charName)}&url=${encodeURIComponent(url)}`, { method: 'POST' });
+                    if (!response.ok) { const e = await response.json(); throw new Error(e.detail || 'Download failed.'); }
+                    const result = await response.json();
+                    _savedStaticUrl = result.url;
+                    avatarUrlInput.value = result.url;
+                    updateAvatarPreview(result.url);
+                    showToast('Avatar saved to static!');
+                } catch (error) {
+                    showToast(`Auto-download failed: ${error.message}`, 'error');
+                    avatarUrlInput.value = originalUrl;
+                } finally {
+                    saveBtn.disabled = false;
+                }
+            }
+
+            let _mirrorTimer = null;
+            avatarUrlInput.addEventListener('input', () => {
+                if (currentAvatarMode !== 'upload') return;
+                const url = avatarUrlInput.value.trim();
+                if (!url.startsWith('http')) return;
+                clearTimeout(_mirrorTimer);
+                _mirrorTimer = setTimeout(() => mirrorUrl(url), 800);
+            });
+
             // Avatar upload logic
             async function uploadFile(file) {
                  if (!file) return;

--- a/static/logs.html
+++ b/static/logs.html
@@ -138,9 +138,10 @@
 
     <script>
     (() => {
-        let LIMIT = 25;
-        let currentTab = new URLSearchParams(location.search).get('tab') === 'admin' ? 'admin' : 'discord';
-        let currentPage = 1;
+        const _qs = new URLSearchParams(location.search);
+        let currentTab = _qs.get('tab') === 'admin' ? 'admin' : 'discord';
+        let currentPage = parseInt(_qs.get('page')) || 1;
+        let LIMIT = parseInt(_qs.get('limit')) || 25;
         let totalItems = 0;
         let channelMap = {};  // channel_id -> {server_name, channel_name}
         let serverNames = {};  // server_id -> server_name
@@ -276,6 +277,7 @@
         document.getElementById('prev-btn').addEventListener('click', () => { if (currentPage > 1) { currentPage--; fetchLogs(); } });
         document.getElementById('next-btn').addEventListener('click', () => { if (currentPage * LIMIT < totalItems) { currentPage++; fetchLogs(); } });
         document.getElementById('limit-select').addEventListener('change', function() { LIMIT = parseInt(this.value); currentPage = 1; fetchLogs(); });
+        document.getElementById('limit-select').value = LIMIT;
 
         // --- Export ---
         document.getElementById('export-btn').addEventListener('click', () => {
@@ -306,6 +308,7 @@
         }
 
         async function fetchLogs() {
+            syncUrl();
             const list = document.getElementById('log-list');
             list.innerHTML = '<div class="text-gray-500 text-center py-12">Loading...</div>';
             try {
@@ -347,6 +350,7 @@
                     <div class="flex items-center gap-3 text-xs text-gray-500 flex-shrink-0">
                         <span title="in/out tokens"><i class="fas fa-coins mr-1"></i>${item.input_tokens || 0}/${item.output_tokens || 0}</span>
                         <span>${fmt(item.timestamp)}</span>
+                        <span class="text-gray-600">#${item.id}</span>
                     </div>
                 </div>
                 <p class="text-xs text-gray-400 truncate">${esc(item.trigger || '')}</p>
@@ -382,8 +386,19 @@
                     ${targetDisplay ? `<span class="text-xs text-gray-400 flex-shrink-0">${esc(targetDisplay)}</span>` : ''}
                     ${item.detail ? `<span class="text-xs text-gray-500 truncate">${esc(item.detail)}</span>` : ''}
                 </div>
-                <span class="text-xs text-gray-500 flex-shrink-0">${fmt(item.timestamp)}</span>
+                <div class="flex items-center gap-3 flex-shrink-0">
+                    <span class="text-xs text-gray-500">${fmt(item.timestamp)}</span>
+                    <span class="text-xs text-gray-600">#${item.id}</span>
+                </div>
             </div>`;
+        }
+
+        function syncUrl() {
+            const p = new URLSearchParams(location.search);
+            p.set('tab', currentTab);
+            p.set('page', currentPage);
+            p.set('limit', LIMIT);
+            history.replaceState(null, '', '?' + p.toString());
         }
 
         function updatePagination() {

--- a/static/scheduler.html
+++ b/static/scheduler.html
@@ -66,6 +66,7 @@
                         <label id="fs-upcoming-row" class="flex items-center gap-3 px-4 py-2 hover:bg-gray-800 cursor-pointer text-sm text-white"><input type="checkbox" value="upcoming" class="filter-status-cb accent-indigo-500"> Upcoming</label>
                         <label id="fs-done-row" class="flex items-center gap-3 px-4 py-2 hover:bg-gray-800 cursor-pointer text-sm text-white"><input type="checkbox" value="done" class="filter-status-cb accent-indigo-500"> Done</label>
                         <label id="fs-disabled-row" class="flex items-center gap-3 px-4 py-2 hover:bg-gray-800 cursor-pointer text-sm text-white"><input type="checkbox" value="disabled" class="filter-status-cb accent-indigo-500"> Disabled</label>
+                        <label id="fs-failed-row" class="flex items-center gap-3 px-4 py-2 hover:bg-gray-800 cursor-pointer text-sm text-white"><input type="checkbox" value="failed" class="filter-status-cb accent-indigo-500"> Failed</label>
                     </div>
                 </div>
                 <div>
@@ -93,6 +94,24 @@
             <div id="task-list" class="space-y-3">
                 <div class="text-gray-500 text-center py-12">Loading...</div>
             </div>
+
+            <!-- Pagination -->
+            <div id="pagination" class="flex items-center justify-between mt-6 text-sm text-gray-400">
+                <div class="flex items-center gap-2">
+                    <span id="pagination-info"></span>
+                    <select id="page-size-select" class="bg-gray-800 border border-gray-700 text-white text-xs rounded-lg px-2 py-1 ml-3">
+                        <option value="10">10</option>
+                        <option value="25" selected>25</option>
+                        <option value="50">50</option>
+                        <option value="100">100</option>
+                    </select>
+                    <span class="text-xs text-gray-500">/ page</span>
+                </div>
+                <div class="flex gap-2">
+                    <button id="prev-btn" class="px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded-lg disabled:opacity-40" disabled>← Prev</button>
+                    <button id="next-btn" class="px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded-lg disabled:opacity-40">Next →</button>
+                </div>
+            </div>
         </div>
     </main>
 
@@ -112,7 +131,7 @@
             <div class="p-5 space-y-3 text-sm">
                 <div class="flex justify-between text-gray-400"><span>Character</span><span id="detail-character" class="text-white"></span></div>
                 <div class="flex justify-between text-gray-400"><span>Target</span><span id="detail-target" class="text-white"></span></div>
-                <div class="flex justify-between text-gray-400"><span>Status</span><span id="detail-status"></span></div>
+                <div class="flex justify-between text-gray-400"><span>Status</span><span id="detail-status" class="flex items-center gap-2 flex-wrap justify-end"></span></div>
                 <div id="detail-time-row" class="flex justify-between text-gray-400"><span>Time</span><span id="detail-time" class="text-white"></span></div>
                 <div id="detail-repeat-row" class="flex justify-between text-gray-400"><span>Repeat</span><span id="detail-repeat" class="text-white"></span></div>
                 <div id="detail-next-run-row" class="hidden flex justify-between text-gray-400"><span>Next run</span><span id="detail-next-run" class="text-indigo-300 font-medium"></span></div>
@@ -397,7 +416,8 @@
                 options = [
                     { value: 'upcoming', label: 'Upcoming' },
                     { value: 'done', label: 'Done' },
-                    { value: 'disabled', label: 'Disabled' }
+                    { value: 'disabled', label: 'Disabled' },
+                    { value: 'failed', label: 'Failed' }
                 ];
             }
             statusSelect.innerHTML = options.map(opt =>
@@ -556,7 +576,7 @@
                 data.forEach(c => { _charCache[c.name] = c; });
             } catch { _charNames = []; }
             makeFilterCombobox('f-character', 'f-character-dd', _charNames);
-            makeFilterCombobox('filter-character', 'filter-character-dd', _charNames, () => renderTasks(allTasks));
+            makeFilterCombobox('filter-character', 'filter-character-dd', _charNames, () => { currentPage = 1; renderTasks(allTasks); });
         }
 
         // --- Target comboboxes ---
@@ -672,6 +692,9 @@
 
         // --- Fetch and render tasks ---
         let allTasks = [];
+        const _sqp = new URLSearchParams(location.search);
+        let PAGE_SIZE = parseInt(_sqp.get('limit')) || 25;
+        let currentPage = parseInt(_sqp.get('page')) || 1;
 
         async function fetchTasks() {
             await ensureCharCache();
@@ -714,16 +737,31 @@
             const filtered = applyFilters(tasks);
             if (!filtered.length) {
                 taskList.innerHTML = '<div class="text-gray-500 text-center py-12"><i class="fas fa-calendar-xmark text-3xl mb-3 block"></i>No tasks found.</div>';
+                updatePagination(0);
                 return;
             }
-            taskList.innerHTML = filtered.map(t => taskCard(t)).join('');
-            // Attach events
+            const start = (currentPage - 1) * PAGE_SIZE;
+            const pageItems = filtered.slice(start, start + PAGE_SIZE);
+            taskList.innerHTML = pageItems.map(t => taskCard(t)).join('');
             taskList.querySelectorAll('[data-action]').forEach(btn => {
                 btn.addEventListener('click', (e) => {
                     if (btn.dataset.action !== 'detail') e.stopPropagation();
                     handleAction(btn.dataset.action, parseInt(btn.dataset.id));
                 });
             });
+            updatePagination(filtered.length);
+        }
+
+        function updatePagination(total) {
+            const p = new URLSearchParams(location.search);
+            p.set('page', currentPage);
+            p.set('limit', PAGE_SIZE);
+            history.replaceState(null, '', '?' + p.toString());
+            const start = total ? (currentPage - 1) * PAGE_SIZE + 1 : 0;
+            const end = Math.min(currentPage * PAGE_SIZE, total);
+            document.getElementById('pagination-info').textContent = total ? `${start}–${end} of ${total}` : '';
+            document.getElementById('prev-btn').disabled = currentPage <= 1;
+            document.getElementById('next-btn').disabled = currentPage * PAGE_SIZE >= total;
         }
 
         function typeBadge(type) {
@@ -738,6 +776,7 @@
                 upcoming:  'bg-blue-900 text-blue-300',
                 done:      'bg-gray-700 text-gray-400',
                 disabled:  'bg-red-900 text-red-300',
+                failed:    'bg-orange-900 text-orange-300',
             };
             return `<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${map[status] || 'bg-gray-700 text-gray-400'}">${status}</span>`;
         }
@@ -860,7 +899,9 @@
             document.getElementById('detail-name').textContent = task.type === 'reminder' ? task.character : normalizeTaskName(task.name);
             document.getElementById('detail-character').textContent = task.character;
             document.getElementById('detail-target').textContent = getTargetLabel(task.target_type, task.target_id);
-            document.getElementById('detail-status').innerHTML = statusBadge(task.status);
+            const httpCode = task.error_message ? (task.error_message.match(/\b([1-5]\d{2})\b/) || [])[1] : null;
+            document.getElementById('detail-status').innerHTML = (httpCode ? `<span class="text-xs text-orange-300">${httpCode}</span>` : '')
+                + statusBadge(task.status);
 
             const timeRow = document.getElementById('detail-time-row');
             const repeatRow = document.getElementById('detail-repeat-row');
@@ -1103,7 +1144,7 @@
                 statusDd.classList.add('hidden');
         });
         document.querySelectorAll('.filter-status-cb').forEach(cb => {
-            cb.addEventListener('change', () => { updateStatusDdLabel(); fetchTasks(); });
+            cb.addEventListener('change', () => { updateStatusDdLabel(); currentPage = 1; fetchTasks(); });
         });
 
         function updateStatusOptions() {
@@ -1122,27 +1163,37 @@
             updateStatusDdLabel();
         }
 
+        // --- Pagination controls ---
+        document.getElementById('prev-btn').addEventListener('click', () => { if (currentPage > 1) { currentPage--; renderTasks(allTasks); } });
+        document.getElementById('next-btn').addEventListener('click', () => { currentPage++; renderTasks(allTasks); });
+        document.getElementById('page-size-select').addEventListener('change', function() { PAGE_SIZE = parseInt(this.value); currentPage = 1; renderTasks(allTasks); });
+        document.getElementById('page-size-select').value = PAGE_SIZE;
+
         // --- Filters ---
         document.getElementById('filter-type').addEventListener('change', () => {
             updateStatusOptions();
+            currentPage = 1;
             fetchTasks();
         });
         ['filter-from','filter-to'].forEach(id => {
-            document.getElementById(id).addEventListener('change', fetchTasks);
+            document.getElementById(id).addEventListener('change', () => { currentPage = 1; fetchTasks(); });
         });
         document.getElementById('clear-filter-btn').addEventListener('click', () => {
             document.getElementById('filter-type').value = '';
             document.getElementById('filter-status').value = '';
             document.getElementById('filter-from').value = '';
             document.getElementById('filter-to').value = '';
+            currentPage = 1;
             fetchTasks();
         });
         document.getElementById('clear-from-btn').addEventListener('click', () => {
             document.getElementById('filter-from').value = '';
+            currentPage = 1;
             fetchTasks();
         });
         document.getElementById('clear-to-btn').addEventListener('click', () => {
             document.getElementById('filter-to').value = '';
+            currentPage = 1;
             fetchTasks();
         });
 

--- a/static/servers.html
+++ b/static/servers.html
@@ -389,13 +389,38 @@
                     }
                     channels.forEach(channel => {
                         const li = document.createElement('li');
-                        li.className = 'list-item px-4 py-2 bg-gray-800 rounded-lg cursor-pointer hover:bg-gray-700';
-                        li.textContent = channel.data.name;
+                        li.className = 'list-item relative flex items-center w-full px-4 py-2 bg-gray-800 rounded-lg cursor-pointer hover:bg-gray-700 group';
                         li.dataset.channelId = channel.channel_id;
+
+                        const nameSpan = document.createElement('span');
+                        nameSpan.textContent = channel.data.name;
+                        nameSpan.className = 'truncate min-w-0 pr-6';
+
+                        const removeBtn = document.createElement('button');
+                        removeBtn.innerHTML = '<i class="fas fa-times"></i>';
+                        removeBtn.className = 'absolute right-2 top-1/2 -translate-y-1/2 text-gray-600 hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity';
+                        removeBtn.title = 'Unregister channel';
+                        removeBtn.addEventListener('click', async (e) => {
+                            e.stopPropagation();
+                            if (!confirm(`Unregister "${channel.data.name}"?`)) return;
+                            try {
+                                const res = await fetch(`${API_BASE}/${currentServer.id}/channels/${channel.channel_id}`, { method: 'DELETE' });
+                                if (!res.ok) throw new Error();
+                                showToast('Channel unregistered.');
+                                if (currentChannel?.channel_id === channel.channel_id) {
+                                    currentChannel = null;
+                                    configPanel.classList.add('hidden');
+                                }
+                                fetchChannels(currentServer.id, currentServer.name);
+                            } catch { showToast('Failed to unregister channel.', 'error'); }
+                        });
+
+                        li.appendChild(nameSpan);
+                        li.appendChild(removeBtn);
                         li.addEventListener('click', () => {
-                             document.querySelectorAll('#channel-list .list-item').forEach(el => el.classList.remove('active'));
+                            document.querySelectorAll('#channel-list .list-item').forEach(el => el.classList.remove('active'));
                             li.classList.add('active');
-                            loadChannelForEdit(channel)
+                            loadChannelForEdit(channel);
                         });
                         channelList.appendChild(li);
                     });


### PR DESCRIPTION
###   Scheduler reliability & error handling

  **Scheduler fixes**
  - Each task runs in its own try/except - one failing task no longer blocks the rest
  - On failure, error_message is persisted to DB and a record is written to discord_logs
  - Scheduler loop is now aligned to wall-clock minutes (:00) instead of a fixed sleep(60)
  - Fixed avatar URL handling for Discord webhooks - local paths (/static/...) are dropped if public_url is not configured

  **Scheduler UI (/scheduler)**
  - New failed status badge (orange)
  - Task detail panel now shows the error message including HTTP status code

  **Task model**
  - Added error_message: Optional[str] = None to the Pydantic Task model - the field was previously stripped from API responses

  ---
  **Admin logging, full coverage**

  Added log_admin calls everywhere they were missing:
  - Characters: import, save_avatar, mirror_avatar, upload_image
  - Servers: server.create, server.delete, channel.create, channel.update
  - Trash: trash.restore
  - Presets: preset.create, preset.update, preset.delete
  - Plugins: plugins.reload

  ---
  **Characters UI**

  - Avatar mode toggle: External URL / Upload (static) with tooltip
  - Tooltips rewritten . shorter copy, no em-dashes
  - Added margin-bottom below the avatar preview

  ---
  **Servers UI**

  - Subtle grey × button on each channel row - unregisters the channel directly from the list without opening the edit form

  ---
  **Infrastructure**

  - docker-compose.yml: removed profiles: ["production"] from the Caddy service - Caddy now starts with a plain docker-compose up